### PR TITLE
Speed Duel Banlist/Cardpool

### DIFF
--- a/lflists/Speed.conf
+++ b/lflists/Speed.conf
@@ -1,0 +1,399 @@
+#[2020.2 Speed Duel]
+!2020.2 Speed Duel
+$whitelist
+#unlimited
+86198326 3 --7 Completed
+24140059 3 --A Cat of Ill Omen
+32207100 3 --A Major Upset
+62325062 3 --Adhesion Trap Hole
+70924884 3 --Alinsection
+64428736 3 --Alligator's Sword
+3366982 3 --Alligator's Sword Dragon
+36629203 3 --Ally of Justice Core Destroyer
+67987611 3 --Amazoness Archers
+29654737 3 --Amazoness Chain Master
+79965360 3 --Amazoness Heirloom
+53162898 3 --Amazoness Sage
+31102447 3 --Amazoness Spy
+94004268 3 --Amazoness Swords Woman
+89567993 3 --Amazoness Trainee
+712559 3 --Amazoness Village
+5183693 3 --Amulet of Ambition
+42431843 3 --Ancient Brain
+89904598 3 --Anthrosaurus
+9156135 3 --Apprentice Magician
+6150044 3 --Arcana Knight Joker
+17896384 3 --Arcane Barrier
+20277860 3 --Armored Zombie
+300202007 3 --Aroma Strategy
+62633180 3 --Assault on GHQ
+48305365 3 --Axe Raider
+88819587 3 --Baby Dragon
+300103003 3 --Bandit
+81480461 3 --Barrel Dragon
+88610708 3 --Bashing Shield
+89091579 3 --Basic Insect
+5053103 3 --Battle Ox
+300202002 3 --Beatdown!
+1474910 3 --Bee List Soldier
+30587695 3 --Beetron
+53606874 3 --Big Insect
+51562916 3 --Big Wave Small Wave
+45547649 3 --Birdface
+41426869 3 --Black Illusion Ritual
+76792184 3 --Black Magic Ritual
+90654356 3 --Black Ptera
+79409334 3 --Black Stego
+38670435 3 --Black Tyranno
+39507162 3 --Blade Knight
+89041555 3 --Blast Held by a Tribute
+26302522 3 --Blast Sphere
+25880422 3 --Block Attack
+97783659 3 --Blood Sucker
+55969226 3 --Blue Dragon Summoner
+35282433 3 --Blue-Eyed Silver Zombie
+23995346 3 --Blue-Eyes Ultimate Dragon
+89631139 3 --Blue-Eyes White Dragon
+8715625 3 --Bokoichi the Freightening Car
+2204140 3 --Book of Life
+63851864 3 --Break! Draw!
+17655904 3 --Burst Stream of Destruction
+78193831 3 --Buster Blader
+300101003 3 --Call of the Haunted (Skill Card)
+52112003 3 --Card Advance
+300102003 3 --Catch of the Day
+82382815 3 --Champion's Vigilance
+18914778 3 --Change Slime
+92667214 3 --Clown Zombie
+40240595 3 --Cocoon of Evolution
+300104004 3 --Cocoon of Ultra Evolution (Skill Card)
+10375182 3 --Command Knight
+40465719 3 --Common Charity
+31000575 3 --Conscription
+26376390 3 --Copycat
+13235258 3 --Corrosive Scales
+23265313 3 --Cost Down
+38289717 3 --Crawling Dragon #2
+53713014 3 --Crazy Fish
+82099401 3 --Crystal Seer
+39978267 3 --Cyber Raider
+63224564 3 --Cyber Shield
+48588176 3 --Danipon
+65287621 3 --Dark Driceratops
+90928333 3 --Dark Factory of Mass Production
+2314238 3 --Dark Magic Attack
+46986414 3 --Dark Magician
+38033121 3 --Dark Magician Girl
+99261403 3 --Dark Rabbit
+45462639 3 --Dark Red Enchanter
+19159413 3 --De-Spell
+10209545 3 --Decayed Commander
+87621407 3 --Dekoichi the Battlechanted Locomotive
+81977953 3 --Desert Twister
+71200730 3 --Despair from the Dark
+300201002 3 --Destiny Draw (Skill Card)
+3493058 3 --Dicephoon
+87880531 3 --Diffusion Wave-Motion
+300302004 3 --Digging for Gold
+300104003 3 --Dino Destruction
+300203001 3 --Dinosaur Kingdom
+30492798 3 --Djinn Disserere of Rituals
+76922029 3 --Don Zaloog
+44436472 3 --Double Coston
+75652080 3 --Double Cyclone
+300103005 3 --Double Evolution Pill (Skill Card)
+300202003 3 --Dragon Caller
+66672569 3 --Dragon Zombie
+20638610 3 --Dragon's Rebirth
+60082869 3 --Dust Tornado
+46508640 3 --Dweller in the Depths
+300101001 3 --Ectoplasmic Fortification!
+90219263 3 --Elegant Egotist
+92755808 3 --Element Saurus
+58818411 3 --Empress Mantis
+30531525 3 --Enchanting Fitting Room
+56916805 3 --Energy Drain
+94716515 3 --Eradicating Aerosol
+95051344 3 --Eternal Rest
+41392891 3 --Feral Imp
+6178850 3 --Fighting Spirit
+300201003 3 --Final Draw
+53581214 3 --Fire Reaper
+51282878 3 --Fishborg Planter
+34460851 3 --Flame Manipulator
+45231177 3 --Flame Swordsman
+300202008 3 --Flight of the Harpies
+75560629 3 --Flint
+83812099 3 --Flint Lock
+69599136 3 --Floodgate Trap Hole
+87430998 3 --Forest
+62337487 3 --Fortress Whale
+77454922 3 --Fortress Whale's Oath
+48206762 3 --Fulfillment of the Contract
+33550694 3 --Fusion Gate
+300302001 3 --Fusion Party!
+18511384 3 --Fusion Recovery
+77491079 3 --Gale Lizard
+19737320 3 --Gatekeeper
+423705 3 --Gearfried the Iron Knight
+57046845 3 --Gearfried the Swordmaster
+54635862 3 --Gentlemander
+72299832 3 --Giant Mech-Soldier
+45894482 3 --Gilasaurus
+36354007 3 --Gilford the Lightning
+84620194 3 --Girochin Kuwagata
+63665875 3 --Goblin Zombie
+14472500 3 --Gokipon
+87102774 3 --Golden Ladybug
+74137509 3 --Graceful Dice
+22134079 3 --Gravekeeper's Ambusher
+25262697 3 --Gravekeeper's Assailant
+99877698 3 --Gravekeeper's Cannonholder
+62473983 3 --Gravekeeper's Chief
+50712728 3 --Gravekeeper's Curse
+300201005 3 --Gravekeeper's Lot
+25524823 3 --Gravekeeper's Oracle
+3381441 3 --Gravekeeper's Priestess
+93023479 3 --Gravekeeper's Recruiter
+58139128 3 --Gravekeeper's Shaman
+63695531 3 --Gravekeeper's Spear Soldier
+99523325 3 --Gravekeeper's Stele
+99690140 3 --Gravekeeper's Vassal
+32022366 3 --Gravity Axe - Grarl
+54622031 3 --Great Mammoth of Goldfine
+10809984 3 --Great Phantom Thief
+13429800 3 --Great White
+300202004 3 --Grit
+73048641 3 --Half Shut
+91932350 3 --Harpie Lady 1
+27927359 3 --Harpie Lady 2
+54415063 3 --Harpie Lady 3
+12206212 3 --Harpie Lady Sisters
+52040216 3 --Harpie's Pet Dragon
+75782277 3 --Harpies' Hunting Ground
+39033131 3 --Haunted Shrine
+45141013 3 --Heat Wave
+300103001 3 --Heavy Metal Raiders (Skill Card)
+47025270 3 --Helping Robo for Combat
+300203004 3 --Hidden Parasite
+70000776 3 --Hidden Temples of Necrovalley
+54579801 3 --High Tide Gyojin
+11925569 3 --Hunting Instinct
+2671330 3 --Hyper Hammerhead
+300203003 3 --Hyper Metamorphosis
+41952656 3 --Imairuka
+7264861 3 --Infernity Beast
+25171661 3 --Infernity Dwarf
+3492538 3 --Insect Armor with Laser Cannon
+22991179 3 --Insect Neglect
+37957847 3 --Insect Princess
+91512835 3 --Insect Queen
+36261276 3 --Interdimensional Matter Transporter
+73431236 3 --Iron Blacksmith Kotetsu
+34559295 3 --Iron Draw
+300201007 3 --It's a Toon World!
+300102004 3 --It's My Lucky Day!
+90876561 3 --Jack's Knight
+98954106 3 --Jar of Avarice
+83968380 3 --Jar of Greed
+16111820 3 --Jurrac Herra
+44689688 3 --Jurrac Spinos
+48411996 3 --Jurrac Stauriko
+62701967 3 --Jurrac Tyrannus
+51934376 3 --Kabazauls
+34627841 3 --Kaibaman
+76634149 3 --Kairyu-Shin
+36021814 3 --King of the Skull Servants
+64788463 3 --King's Knight
+56283725 3 --Kumootoko
+37390589 3 --Kunai with Chain
+77007920 3 --Laser Cannon Armor
+300202005 3 --Last Gamble
+87322377 3 --Launcher Spider
+61854111 3 --Legendary Sword
+25280974 3 --Legion the Fiend Jester
+37721209 3 --Levia-Dragon - Daedalus
+49587034 3 --Lightforce Sword
+82324105 3 --Limit Impulse
+90790253 3 --Little-Winguard
+17985575 3 --Lord of D.
+95231062 3 --Lost Blue Breaker
+300302003 3 --Low Blow
+17658803 3 --Luster Dragon #2
+25769732 3 --Machine Conversion Factory
+79870141 3 --Mad Sword Beast
+77414722 3 --Magic Jammer
+46474915 3 --Magical Ghost
+7802006 3 --Magical Plant Mandragola
+30608985 3 --Magical Undertaker
+30208479 3 --Magician of Black Chaos
+31560081 3 --Magician of Faith
+50755 3 --Magician's Circle
+36045450 3 --Magicians Unite
+54652250 3 --Man-Eater Bug
+71466592 3 --Maryokutai
+44287299 3 --Masaki the Legendary Swordsman
+28933734 3 --Mask of Darkness
+56948373 3 --Mask of the Accursed
+25727454 3 --Master Craftsman Gamil
+65957473 3 --Metal Armored Bug
+68540059 3 --Metalmorph
+90660762 3 --Meteor B. Dragon
+64271667 3 --Meteor Dragon
+37580756 3 --Michizure
+300201009 3 --Millennium Eye (Skill Card)
+300201006 3 --Millennium Necklace (Skill Card)
+88032456 3 --Mimicat
+300201008 3 --Mind Scan (Skill Card)
+22123627 3 --Moray of Greed
+50913601 3 --Mountain
+68516705 3 --Mystic Horseman
+15025844 3 --Mystical Elf
+300102002 3 --Mythic Depths
+89882100 3 --Night Beam
+300203002 3 --Nightmare Sonic Blast!
+78986941 3 --Order to Charge
+39019325 3 --Order to Smash
+300202006 3 --Pal-O'Mine-zation!
+14457896 3 --Parasite Paranoid
+62762898 3 --Parrot Dragon
+19153634 3 --Patrician of Darkness
+300202001 3 --Peak Performance
+24433920 3 --Pendulum Machine
+48579379 3 --Perfectly Ultimate Great Moth
+58192742 3 --Petit Moth
+63571750 3 --Pharaoh's Treasure
+26185991 3 --Pinch Hopper
+24094653 3 --Polymerization
+52860176 3 --Possessed Dark Soul
+300201001 3 --Power of Dark
+77027445 3 --Power of Kaishin
+300201004 3 --Prescience
+66835946 3 --Pyramid of Wonders
+25652259 3 --Queen's Knight
+94905343 3 --Rabid Horseman
+51267887 3 --Raise Body Heat
+31785398 3 --Ready for Intercepting
+74677422 3 --Red-Eyes B. Dragon
+44397496 3 --Red-Eyes Spirit
+17814387 3 --Reinforcements
+75417459 3 --Release Restraint
+64631466 3 --Relinquished
+34016756 3 --Riryoku
+30450531 3 --Rite of Spirit
+300302002 3 --Ritual Ceremony
+83258273 3 --Robbin' Zombie
+91939608 3 --Rogue Doll
+300101004 3 --Royal Flush
+49868263 3 --Ryu Senshi
+24611934 3 --Ryu-Kishin Powered
+13604200 3 --Sage's Stone
+16222645 3 --Sasuke Samurai
+81443745 3 --Sealing Ceremony of Suiton
+22537443 3 --Sebek's Blessing
+26533075 3 --Security Orb
+23401839 3 --Senju of the Thousand Hands
+66516792 3 --Serpent Night Dragon
+300103004 3 --Servants of the Fallen King
+3819470 3 --Seven Tools of the Bandit
+58621589 3 --Shadow of Eyes
+33904024 3 --Shard of Greed
+56830749 3 --Share the Pain
+52097679 3 --Shield & Sword
+14771222 3 --Shore Knight
+8131171 3 --Sinister Serpent
+27655513 3 --Skreech
+126218 3 --Skull Dice
+2504891 3 --Skull Knight
+32274490 3 --Skull Servant
+3797883 3 --Slot Machine
+84650463 3 --Slushy
+86318356 3 --Sogen
+57617178 3 --Sonic Bird
+84696266 3 --Sonic Duck
+40384720 3 --Sonic Shooter
+39041729 3 --Spacetime Transcendence
+75014062 3 --Spell Power Grasp
+300103002 3 --Spell Proof Armor
+18807109 3 --Spellbinding Circle
+33245030 3 --Sphere Kuriboh
+56051648 3 --Spider Egg
+67957315 3 --Spirit Ryu
+81385346 3 --Stamping Destruction
+300101002 3 --Straight to the Grave
+60764581 3 --Stray Lambs
+79816536 3 --Summoner's Art
+33951077 3 --Super War-Lion
+6849042 3 --Super-Ancient Dinobeast
+33057951 3 --Surface
+300104005 3 --Switcheroo
+37120512 3 --Sword of Dark Destruction
+98495314 3 --Sword of Deep-Seated
+61405855 3 --Sword of Dragon's Soul
+83682725 3 --Tail Swipe
+28725004 3 --Tainted Wisdom
+300104002 3 --Terror from the Deep!
+73680966 3 --The Beginning of the End
+34694160 3 --The Eye of Truth
+43973174 3 --The Flute of Summoning Dragon
+94861297 3 --The Forceful Checkpoint
+42671151 3 --The Golden Apples
+3643300 3 --The Legendary Fisherman
+19801646 3 --The Legendary Fisherman II
+43434803 3 --The Shallow Grave
+29491031 3 --The Snake Hair
+87557188 3 --The Stern Mystic
+300102001 3 --The World's Greatest Fisherman
+51838385 3 --Theban Nightmare
+41462083 3 --Thousand Dragon
+63391643 3 --Thousand Knives
+80987696 3 --Time Machine
+71625222 3 --Time Wizard
+300101005 3 --Tomb of the Pharaoh
+46457856 3 --Tomozaurus
+59383041 3 --Toon Alligator
+43509019 3 --Toon Defense
+16392422 3 --Toon Masked Sorcerer
+65458948 3 --Toon Mermaid
+70560957 3 --Toon Rollback
+91842653 3 --Toon Summoned Skull
+89997728 3 --Toon Table of Contents
+15259703 3 --Toon World
+19252988 3 --Trap Jammer
+12181376 3 --Triangle Ecstasy Spark
+300202009 3 --Tribal Synergy
+2903036 3 --Tribute Doll
+55013285 3 --Troop Dragon
+3149764 3 --Tutan Mask
+43586926 3 --Twin-Headed Behemoth
+45939841 3 --Twister
+94119974 3 --Two-Headed King Rex
+94568601 3 --Tyrant Dragon
+22431243 3 --Ultra Evolution Pill
+22702055 3 --Umi
+1784619 3 --Uraby
+53839837 3 --Vampire Lord
+90434926 3 --Veil of Darkness
+80402389 3 --Verdant Sanctuary
+15052462 3 --Violet Crystal
+300102005 3 --Viral Infection
+10813327 3 --Waking the Dragon
+54539105 3 --War-Lion Ritual
+75953262 3 --Warrior Dai Grepher
+90873992 3 --Warrior Elimination
+23424603 3 --Wasteland
+49669730 3 --Water Hazard
+96643568 3 --Wetha
+91996584 3 --Whiptail Crow
+18756904 3 --White Elephant's Gift
+68427465 3 --Wicked-Breaking Flamberge - Baou
+47766694 3 --Wild Tornado
+59744639 3 --Windstorm of Etaqua
+39175982 3 --Winged Cleaver
+67775894 3 --Wonder Wand
+43140791 3 --Worm Bait
+59197169 3 --Yami
+51534754 3 --Yomi Ship
+300104001 3 --Zombie Master (Skill Card)
+47693640 3 --Zombie Tiger
+81616639 3 --Zombina


### PR DESCRIPTION
The Card pool as whitelisted banlist for the TCG Speed Duel format
Source: https://db.ygoprodeck.com/search/?&format=Speed%20Duel